### PR TITLE
Fix NPE on object without properties

### DIFF
--- a/modules/swagger-codegen/src/main/java/io/swagger/codegen/DefaultCodegen.java
+++ b/modules/swagger-codegen/src/main/java/io/swagger/codegen/DefaultCodegen.java
@@ -1892,7 +1892,7 @@ public class DefaultCodegen {
             setNonArrayMapProperty(property, type);
             if ("object".equals(p.getType()) && p instanceof ObjectProperty) {
                 ObjectProperty op = (ObjectProperty) p;
-                if (op.getProperties().isEmpty()) {
+                if (op.getProperties() == null || op.getProperties().isEmpty()) {
                     property.isFreeFormObject = true;
                 }
             }


### PR DESCRIPTION
### Description of the PR

The codegen was failing when using free objects as body parameters such as:
```
      "parameters": [
          {
            "name": "param",
            "in": "body",
            "required": true,
            "schema": {
              "type": "object",
              "additionalProperties": true
            }
          }
        ]
```
